### PR TITLE
修正getIndexs()无法正确解析使用\r\n换行的标题

### DIFF
--- a/lib/doxmate.js
+++ b/lib/doxmate.js
@@ -116,7 +116,7 @@ exports.getIndexs = function (section, level, filter) {
   level = level > 6 ? 6 : level; // 最大到6级标题
   level = level < 1 ? 1 : level; // 最小到1级标题
   filter = filter || function (item) {return true;};
-  var matched = section.match(/.*\n(\=+)|#+\s+(.*)/gm);
+  var matched = section.match(/.*\r?\n(\=+)|#+\s+(.*)/gm);
   if (matched) {
     return matched.map(function (item) {
       if (/#+/.test(item)) {


### PR DESCRIPTION
如以下类型的标题：

```
标题
=======
```

当使用\r\n换行时，无法正确取得该标题（空字符串的）
