### PR TITLE
execFile方法在win10x64执行doxmate-build出错，改了

### DIFF
--- a/bin/doxmate
+++ b/bin/doxmate
@@ -61,10 +61,17 @@ if (fs.existsSync(local)) {
 
 // execute command
 var options = {maxBuffer: 1024 * 1024};
-execFile(local, args, options, function (err, stdout) {
-  if (err) {
+execFile("node", [local], function (err, stdout) {
+    if (err) {
     console.error(err);
     return;
-  }
-  console.log(stdout);
+    }
+    console.log(stdout);
 });
+// execFile(local, args, options, function (err, stdout) {
+//   if (err) {
+//     console.error(err);
+//     return;
+//   }
+//   console.log(stdout);
+// });


### PR DESCRIPTION
./bin/doxmate这个文件的
// execFile(local, args, options, function (err, stdout) {
//   if (err) {
//     console.error(err);
//     return;
//   }
//   console.log(stdout);
// });
改为
execFile("node", [local], function (err, stdout) {
    if (err) {
    console.error(err);
    return;
    }
    console.log(stdout);
});在win10x64可以执行成功